### PR TITLE
Removing custom Data type and cleaning up code

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -28,13 +28,13 @@ func TestSend(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, err := NewClientWithHTTP(nil, "test", server.URL)
+		client, err := NewClientFromHTTP(nil, "test", server.URL)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		resp, err := client.Send(&Message{
 			Token: "test",
-			Data: &Data{
+			Data: map[string]interface{}{
 				"foo": "bar",
 			},
 		})
@@ -58,13 +58,13 @@ func TestSend(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, err := NewClientWithHTTP(&http.Client{}, "test", server.URL)
+		client, err := NewClientFromHTTP(&http.Client{}, "test", server.URL)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		resp, err := client.Send(&Message{
 			Token: "test",
-			Data: &Data{
+			Data: map[string]interface{}{
 				"foo": "bar",
 			},
 		})
@@ -77,14 +77,14 @@ func TestSend(t *testing.T) {
 	})
 
 	t.Run("send=invalid_token", func(t *testing.T) {
-		_, err := NewClientWithHTTP(&http.Client{}, "", "")
+		_, err := NewClientFromHTTP(&http.Client{}, "", "")
 		if err == nil {
 			t.Fatal("expected error but got nil")
 		}
 	})
 
 	t.Run("send=invalid_message", func(t *testing.T) {
-		c, err := NewClientWithHTTP(&http.Client{}, "test", "test")
+		c, err := NewClientFromHTTP(&http.Client{}, "test", "test")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -114,13 +114,13 @@ func TestSend(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, err := NewClientWithHTTP(&http.Client{}, "test", server.URL)
+		client, err := NewClientFromHTTP(&http.Client{}, "test", server.URL)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		resp, err := client.Send(&Message{
 			Token: "test",
-			Data: &Data{
+			Data: map[string]interface{}{
 				"foo": "bar",
 			},
 		})
@@ -154,13 +154,13 @@ func TestSendWithRetry(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, err := NewClientWithHTTP(&http.Client{}, "test", server.URL)
+		client, err := NewClientFromHTTP(&http.Client{}, "test", server.URL)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		resp, err := client.SendWithRetry(&Message{
 			Token: "test",
-			Data: &Data{
+			Data: map[string]interface{}{
 				"foo": "bar",
 			},
 		}, 3)
@@ -184,13 +184,13 @@ func TestSendWithRetry(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, err := NewClientWithHTTP(&http.Client{}, "test", server.URL)
+		client, err := NewClientFromHTTP(&http.Client{}, "test", server.URL)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		resp, err := client.SendWithRetry(&Message{
 			Token: "test",
-			Data: &Data{
+			Data: map[string]interface{}{
 				"foo": "bar",
 			},
 		}, 2)
@@ -229,13 +229,13 @@ func TestSendWithRetry(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, err := NewClientWithHTTP(&http.Client{}, "test", server.URL)
+		client, err := NewClientFromHTTP(&http.Client{}, "test", server.URL)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		resp, err := client.SendWithRetry(&Message{
 			Token: "test",
-			Data: &Data{
+			Data: map[string]interface{}{
 				"foo": "bar",
 			},
 		}, 4)
@@ -255,7 +255,7 @@ func TestSendWithRetry(t *testing.T) {
 	})
 
 	t.Run("send_with_retry=failure_retry", func(t *testing.T) {
-		client, err := NewClientWithHTTP(&http.Client{
+		client, err := NewClientFromHTTP(&http.Client{
 			Timeout: time.Nanosecond,
 		}, "test", "127.0.0.1:80")
 		if err != nil {
@@ -263,7 +263,7 @@ func TestSendWithRetry(t *testing.T) {
 		}
 		resp, err := client.SendWithRetry(&Message{
 			Token: "test",
-			Data: &Data{
+			Data: map[string]interface{}{
 				"foo": "bar",
 			},
 		}, 3)

--- a/message.go
+++ b/message.go
@@ -5,32 +5,19 @@ import "errors"
 var (
 	// ErrInvalidMessage occurs if push notitication message is nil.
 	ErrInvalidMessage = errors.New("message is invalid")
+
 	// ErrInvalidToken occurs if device token is empty.
 	ErrInvalidToken = errors.New("device token is invalid")
+
 	// ErrToManyRegIDs occurs when registration ids more then 1000.
 	ErrToManyRegIDs = errors.New("too many registrations ids")
+
 	// ErrInvalidTimeToLive occurs if TimeToLive more then 2419200.
 	ErrInvalidTimeToLive = errors.New("messages time-to-live is invalid")
 )
 
-// Message represents list of targets, options, and payload for HTTP JSON messages.
-type Message struct {
-	Token                    string        `json:"to,omitempty"`
-	RegistrationIDs          []string      `json:"registration_ids,omitempty"`
-	Condition                string        `json:"condition,omitempty"`
-	CollapseKey              string        `json:"collapse_key,omitempty"`
-	Priority                 string        `json:"priority,omitempty"`
-	ContentAvailable         bool          `json:"content_available,omitempty"`
-	DelayWhileIdle           bool          `json:"delay_while_idle,omitempty"`
-	TimeToLive               int           `json:"time_to_live,omitempty"`
-	DeliveryReceiptRequested bool          `json:"delivery_receipt_requested,omitempty"`
-	DryRun                   bool          `json:"dry_run,omitempty"`
-	Notification             *Notification `json:"notification,omitempty"`
-	Data                     *Data         `json:"data,omitempty"`
-}
-
-// Notification specifies the predefined, user-visible key-value pairs
-// of the notification payload
+// Notification specifies the predefined, user-visible key-value pairs of the
+// notification payload.
 type Notification struct {
 	Title        string `json:"title,omitempty"`
 	Body         string `json:"body,omitempty"`
@@ -46,20 +33,38 @@ type Notification struct {
 	TitleLocArgs string `json:"title_loc_args,omitempty"`
 }
 
-// Data specifies the custom key-value pairs of the message's payload.
-type Data map[string]interface{}
+// Message represents list of targets, options, and payload for HTTP JSON
+// messages.
+type Message struct {
+	Token                    string                 `json:"to,omitempty"`
+	RegistrationIDs          []string               `json:"registration_ids,omitempty"`
+	Condition                string                 `json:"condition,omitempty"`
+	CollapseKey              string                 `json:"collapse_key,omitempty"`
+	Priority                 string                 `json:"priority,omitempty"`
+	ContentAvailable         bool                   `json:"content_available,omitempty"`
+	DelayWhileIdle           bool                   `json:"delay_while_idle,omitempty"`
+	TimeToLive               int                    `json:"time_to_live,omitempty"`
+	DeliveryReceiptRequested bool                   `json:"delivery_receipt_requested,omitempty"`
+	DryRun                   bool                   `json:"dry_run,omitempty"`
+	Notification             *Notification          `json:"notification,omitempty"`
+	Data                     map[string]interface{} `json:"data,omitempty"`
+}
 
 // Validate returns an error if the message is not well-formed.
 func (msg *Message) Validate() error {
 	switch {
 	case msg == nil:
 		return ErrInvalidMessage
+
 	case msg.Token == "" && len(msg.RegistrationIDs) == 0:
 		return ErrInvalidToken
+
 	case len(msg.RegistrationIDs) > 1000:
 		return ErrToManyRegIDs
+
 	case msg.TimeToLive > 2419200:
 		return ErrInvalidTimeToLive
+
 	default:
 		return nil
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -3,7 +3,7 @@ package fcm
 import "testing"
 
 func TestValidate(t *testing.T) {
-	t.Run("validaate=to_many_reg_ids", func(t *testing.T) {
+	t.Run("validate=to_many_reg_ids", func(t *testing.T) {
 		msg := &Message{
 			Token:           "test",
 			RegistrationIDs: []string{"reg_id"},

--- a/response.go
+++ b/response.go
@@ -8,37 +8,48 @@ import (
 var (
 	// ErrMissingRegistration occurs if registration token is not set.
 	ErrMissingRegistration = errors.New("missing registration token")
+
 	// ErrInvalidRegistration occurs if registration token is invalid.
 	ErrInvalidRegistration = errors.New("invalid registration token")
-	// ErrNotRegistered occurs when application was deleted from device
-	// and token is not registered in FCM.
+
+	// ErrNotRegistered occurs when application was deleted from device and
+	// token is not registered in FCM.
 	ErrNotRegistered = errors.New("unregistered device")
+
 	// ErrInvalidPackageName occurs if package name in message is invalid.
 	ErrInvalidPackageName = errors.New("invalid package name")
+
 	// ErrMismatchSenderID occurs when application has a new registration token.
 	ErrMismatchSenderID = errors.New("mismatched sender id")
+
 	// ErrMessageTooBig occurs when message is too big.
 	ErrMessageTooBig = errors.New("message is too big")
+
 	// ErrInvalidDataKey occurs if data key is invalid.
 	ErrInvalidDataKey = errors.New("invalid data key")
+
 	// ErrInvalidTTL occurs when message has invalid TTL.
 	ErrInvalidTTL = errors.New("invalid time to live")
-	// ErrUnavailable occurs when FCM service is unavailable.
-	//  It makes sense to retry after this error.
+
+	// ErrUnavailable occurs when FCM service is unavailable. It makes sense
+	// to retry after this error.
 	ErrUnavailable = connectionError("timeout")
-	// ErrInternalServerError is internal FCM error.
-	// It makes sense to retry after this error.
-	ErrInternalServerError = serverError("internal server error")
-	// ErrDeviceMessageRateExceeded occurs when client sent to many requests
-	// to the device.
+
+	// ErrInternalServerError is internal FCM error. It makes sense to retry
+	// after this error.
+	ErrInternalServerError = ServerError("internal server error")
+
+	// ErrDeviceMessageRateExceeded occurs when client sent to many requests to
+	// the device.
 	ErrDeviceMessageRateExceeded = errors.New("device message rate exceeded")
-	// ErrTopicsMessageRateExceeded occurs when client sent to many requests
-	// to the topics.
+
+	// ErrTopicsMessageRateExceeded occurs when client sent to many requests to
+	// the topics.
 	ErrTopicsMessageRateExceeded = errors.New("topics message rate exceeded")
 )
 
 var (
-	httpErrorsMapper = map[string]error{
+	errMap = map[string]error{
 		"MissingRegistration":       ErrMissingRegistration,
 		"InvalidRegistration":       ErrInvalidRegistration,
 		"NotRegistered":             ErrNotRegistered,
@@ -70,19 +81,19 @@ func (err connectionError) Timeout() bool {
 	return true
 }
 
-// serverError represents internal server errors.
+// ServerError represents internal server errors.
 // Implements `net.Error` interface.
-type serverError string
+type ServerError string
 
-func (err serverError) Error() string {
+func (err ServerError) Error() string {
 	return string(err)
 }
 
-func (serverError) Temporary() bool {
+func (ServerError) Temporary() bool {
 	return true
 }
 
-func (serverError) Timeout() bool {
+func (ServerError) Timeout() bool {
 	return false
 }
 
@@ -117,7 +128,8 @@ func (r *Result) UnmarshalJSON(data []byte) error {
 
 	r.MessageID = result.MessageID
 	r.RegistrationID = result.RegistrationID
-	r.Error = httpErrorsMapper[result.Error]
+	r.Error = errMap[result.Error]
+
 	return nil
 }
 
@@ -128,6 +140,7 @@ func (r Result) Unregistered() bool {
 	switch r.Error {
 	case ErrNotRegistered, ErrMismatchSenderID, ErrMissingRegistration, ErrInvalidRegistration:
 		return true
+
 	default:
 		return false
 	}

--- a/retry.go
+++ b/retry.go
@@ -18,9 +18,11 @@ func retry(fn func() error, attempts int) error {
 		if err == nil {
 			return nil
 		}
+
 		if tErr, ok := err.(net.Error); !ok || !tErr.Temporary() {
 			return err
 		}
+
 		attempt++
 		backoff := minBackoff * time.Duration(attempt*attempt)
 		if attempt > attempts || backoff > maxBackoff {


### PR DESCRIPTION
I rewrote some aspects of the code to remove the custom `fcm.Data` type, which makes it significantly easier to use when sending more structured data. I also cleaned up some of the comments and names, in order to make the code more "idiomatic." 

Really great package though! I hope you don't mind my insolence in submitting this -- I just wanted the interface to be more similar to other Go client packages. Really appreciate this package!